### PR TITLE
refactor: migrar vistas para usar layouts.app en lugar de adminlte

### DIFF
--- a/resources/views/admin/permissions/create.blade.php
+++ b/resources/views/admin/permissions/create.blade.php
@@ -1,4 +1,4 @@
-@extends('adminlte::page')
+@extends('layouts.app')
 
 @section('title', 'Crear Permiso')
 

--- a/resources/views/admin/permissions/edit.blade.php
+++ b/resources/views/admin/permissions/edit.blade.php
@@ -1,4 +1,4 @@
-@extends('adminlte::page')
+@extends('layouts.app')
 
 @section('title', 'Editar Permiso')
 

--- a/resources/views/admin/permissions/index.blade.php
+++ b/resources/views/admin/permissions/index.blade.php
@@ -1,4 +1,4 @@
-@extends('adminlte::page')
+@extends('layouts.app')
 
 @section('title', 'Permisos')
 

--- a/resources/views/admin/roles/create.blade.php
+++ b/resources/views/admin/roles/create.blade.php
@@ -1,4 +1,4 @@
-@extends('adminlte::page')
+@extends('layouts.app')
 
 @section('title', 'Crear Rol')
 

--- a/resources/views/admin/roles/edit.blade.php
+++ b/resources/views/admin/roles/edit.blade.php
@@ -1,4 +1,4 @@
-@extends('adminlte::page')
+@extends('layouts.app')
 
 @section('title', 'Editar Rol')
 

--- a/resources/views/admin/roles/index.blade.php
+++ b/resources/views/admin/roles/index.blade.php
@@ -1,4 +1,4 @@
-@extends('adminlte::page')
+@extends('layouts.app')
 
 @section('title', 'Roles')
 

--- a/resources/views/centro/create.blade.php
+++ b/resources/views/centro/create.blade.php
@@ -1,4 +1,4 @@
-@extends('adminlte::page')
+@extends('layouts.app')
 
 @section('title', 'Agregar Centro')
 

--- a/resources/views/centro/edit.blade.php
+++ b/resources/views/centro/edit.blade.php
@@ -1,4 +1,4 @@
-@extends('adminlte::page')
+@extends('layouts.app')
 
 @section('title', 'Centros')
 

--- a/resources/views/centro/index.blade.php
+++ b/resources/views/centro/index.blade.php
@@ -1,4 +1,4 @@
-@extends('adminlte::page')
+@extends('layouts.app')
 
 @section('title', 'Centros')
 

--- a/resources/views/competencias/index.blade.php
+++ b/resources/views/competencias/index.blade.php
@@ -1,4 +1,4 @@
-@extends('adminlte::page')
+@extends('layouts.app')
 
 @section('title', 'Competencias')
 

--- a/resources/views/dashboard.blade.php
+++ b/resources/views/dashboard.blade.php
@@ -1,4 +1,4 @@
-@extends('adminlte::page')
+@extends('layouts.app')
 
 @section('title', 'Panel de control')
 

--- a/resources/views/home.blade.php
+++ b/resources/views/home.blade.php
@@ -1,4 +1,4 @@
-@extends('adminlte::page')
+@extends('layouts.app')
 
 @section('title', 'Dashboard')
 
@@ -15,11 +15,11 @@
 </div>
 
 <div class="container my-4">
-    <div id="carouselExampleDark" class="carousel carousel-dark slide" data-bs-ride="carousel">
+    <div id="carouselDark" class="carousel carousel-dark slide" data-bs-ride="carousel">
         <div class="carousel-indicators">
-            <button type="button" data-bs-target="#carouselExampleDark" data-bs-slide-to="0" class="active" aria-current="true" aria-label="Slide 1"></button>
-            <button type="button" data-bs-target="#carouselExampleDark" data-bs-slide-to="1" aria-label="Slide 2"></button>
-            <button type="button" data-bs-target="#carouselExampleDark" data-bs-slide-to="2" aria-label="Slide 3"></button>
+            <button type="button" data-bs-target="#carouselDark" data-bs-slide-to="0" class="active" aria-current="true" aria-label="Slide 1"></button>
+            <button type="button" data-bs-target="#carouselDark" data-bs-slide-to="1" aria-label="Slide 2"></button>
+            <button type="button" data-bs-target="#carouselDark" data-bs-slide-to="2" aria-label="Slide 3"></button>
         </div>
         <div class="carousel-inner">
             <div class="carousel-item active" data-bs-interval="10000">
@@ -44,11 +44,11 @@
                 </div>
             </div>
         </div>
-        <button class="carousel-control-prev" type="button" data-bs-target="#carouselExampleDark" data-bs-slide="prev">
+        <button class="carousel-control-prev" type="button" data-bs-target="#carouselDark" data-bs-slide="prev">
             <span class="carousel-control-prev-icon" aria-hidden="true"></span>
             <span class="visually-hidden">Previous</span>
         </button>
-        <button class="carousel-control-next" type="button" data-bs-target="#carouselExampleDark" data-bs-slide="next">
+        <button class="carousel-control-next" type="button" data-bs-target="#carouselDark" data-bs-slide="next">
             <span class="carousel-control-next-icon" aria-hidden="true"></span>
             <span class="visually-hidden">Next</span>
         </button>

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -3,8 +3,20 @@
 @section('title', config('app.name', 'SENA'))
 
 @section('content')
-<div class="container-fluid">
-    @yield('content')
+<div class="container-fluid py-3">
+    @hasSection('content_header')
+    <div class="row mb-2">
+        <div class="col-12">
+            @yield('content_header')
+        </div>
+    </div>
+    @endif
+
+    <div class="row">
+        <div class="col-12">
+            @yield('content')
+        </div>
+    </div>
 </div>
 @endsection
 

--- a/resources/views/user/create.blade.php
+++ b/resources/views/user/create.blade.php
@@ -1,4 +1,4 @@
-@extends('adminlte::page')
+@extends('layouts.app')
 
 @section('title', 'Crear Usuario')
 

--- a/resources/views/user/edit.blade.php
+++ b/resources/views/user/edit.blade.php
@@ -1,4 +1,4 @@
-@extends('adminlte::page')
+@extends('layouts.app')
 
 @section('title', 'Editar Usuario')
 

--- a/resources/views/user/index.blade.php
+++ b/resources/views/user/index.blade.php
@@ -1,4 +1,4 @@
-@extends('adminlte::page')
+@extends('layouts.app')
 
 @section('title', 'Usuarios')
 

--- a/resources/views/user/show.blade.php
+++ b/resources/views/user/show.blade.php
@@ -1,4 +1,4 @@
-@extends('adminlte::page')
+@extends('layouts.app')
 
 @section('title', 'Ver Usuario')
 


### PR DESCRIPTION
- Reemplazar @extends('adminlte::page') con @extends('layouts.app') en todas las vistas
- Eliminar directiva @implement('layouts.app') de home.blade.php
- Mejorar estructura de layouts/app.blade.php:
  - Agregar soporte opcional para sección content_header
  - Agregar padding py-3 a container-fluid
  - Envolver contenido en estructura Bootstrap row/col apropiada
  - Mejorar espaciado y jerarquía visual