### PR TITLE
fix: validación de permisos en centros y sincronización de campos en ofertas

### DIFF
--- a/app/Http/Controllers/CentroController.php
+++ b/app/Http/Controllers/CentroController.php
@@ -63,26 +63,24 @@ class CentroController extends Controller
 
     /**
      * Despliega el formulario para editar el recurso especificado
-     * @param string $id
+     * @param Centro $centro
      * @return \Illuminate\Contracts\View\View
      */
-    public function edit(string $id)
+    public function edit(Centro $centro)
     {
-        Gate::authorize('centros.update', $id);
-        $centro = Centro::findOrFail($id);
+        Gate::authorize('centros.update', $centro);
         return view('centros.edit', compact('centro'));
     }
 
     /**
      * Actualiza el recurso especificado en almacenamiento
      * @param Request $request
-     * @param string $id
+     * @param Centro $centro
      * @return \Illuminate\Http\RedirectResponse
      */
-    public function update(Request $request, string $id)
+    public function update(Request $request, Centro $centro)
     {
-        Gate::authorize('centros.update', $id);
-        $centro = Centro::findOrFail($id);
+        Gate::authorize('centros.update', $centro);
         $data = $request->validate([
             'nombre' => 'required|string|max:255',
             'direccion' => 'required|string|max:255',

--- a/app/Http/Controllers/OfertaController.php
+++ b/app/Http/Controllers/OfertaController.php
@@ -3,6 +3,7 @@
 namespace App\Http\Controllers;
 
 use App\Models\Oferta;
+use App\Models\Centro;
 use Illuminate\Support\Facades\Gate;
 use Illuminate\Http\Request;
 
@@ -26,7 +27,8 @@ class OfertaController extends Controller
     public function create()
     {
         Gate::authorize('ofertas.create', Oferta::class);
-        return view('ofertas.create');
+        $centros = Centro::all();
+        return view('ofertas.create', compact('centros'));
     }
 
      /**
@@ -60,7 +62,8 @@ class OfertaController extends Controller
     public function edit(Oferta $oferta)
     {
         Gate::authorize('ofertas.update', $oferta);
-        return view('ofertas.edit', compact('oferta'));
+        $centros = Centro::all();
+        return view('ofertas.edit', compact('oferta', 'centros'));
     }
 
     /**

--- a/resources/views/centros/edit.blade.php
+++ b/resources/views/centros/edit.blade.php
@@ -35,7 +35,7 @@
         {{-- Formulario --}}
         <div class="col-12 md-4">
             @canany(['centros.edit','centros.update'])
-            <form action="{{ route('centro.update', $centro->id) }}" method="POST">
+            <form action="{{ route('centros.update', $centro->id) }}" method="POST">
                 @csrf
                 @method('PUT')
 

--- a/resources/views/ofertas/create.blade.php
+++ b/resources/views/ofertas/create.blade.php
@@ -46,14 +46,27 @@
                                class="form-control">
                     </div>
 
+                    {{-- Centro --}}
+                    <div class="form-group">
+                        <label for="centro_id"><strong>Centro</strong></label>
+                        <select name="centro_id" id="centro_id" class="form-control" required>
+                            <option value="">Seleccione un centro</option>
+                            @foreach($centros ?? [] as $centro)
+                                <option value="{{ $centro->id }}">{{ $centro->nombre }}</option>
+                            @endforeach
+                        </select>
+                    </div>
+
                     {{-- Año --}}
                     <div class="form-group">
-                        <label for="anio"><strong>Año</strong></label>
+                        <label for="año"><strong>Año</strong></label>
                         <input type="number"
-                               name="anio"
-                               id="anio"
+                               name="año"
+                               id="año"
                                placeholder="Ingrese el año"
-                               class="form-control">
+                               class="form-control"
+                               min="2000"
+                               max="2099">
                     </div>
 
                     {{-- Fecha inicio --}}
@@ -65,12 +78,12 @@
                                class="form-control">
                     </div>
 
-                    {{-- Fecha final --}}
+                    {{-- Fecha fin --}}
                     <div class="form-group">
-                        <label for="fecha_final"><strong>Fecha final</strong></label>
+                        <label for="fecha_fin"><strong>Fecha fin</strong></label>
                         <input type="date"
-                               name="fecha_final"
-                               id="fecha_final"
+                               name="fecha_fin"
+                               id="fecha_fin"
                                class="form-control">
                     </div>
 

--- a/resources/views/ofertas/edit.blade.php
+++ b/resources/views/ofertas/edit.blade.php
@@ -47,14 +47,27 @@
                                class="form-control">
                     </div>
 
+                    {{-- Centro --}}
+                    <div class="form-group">
+                        <label for="centro_id"><strong>Centro</strong></label>
+                        <select name="centro_id" id="centro_id" class="form-control" required>
+                            <option value="">Seleccione un centro</option>
+                            @foreach($centros ?? [] as $centro)
+                                <option value="{{ $centro->id }}" {{ $oferta->centro_id == $centro->id ? 'selected' : '' }}>{{ $centro->nombre }}</option>
+                            @endforeach
+                        </select>
+                    </div>
+
                     {{-- Año --}}
                     <div class="form-group">
-                        <label for="anio"><strong>Año</strong></label>
+                        <label for="año"><strong>Año</strong></label>
                         <input type="number"
-                               name="anio"
-                               id="anio"
-                               value="{{ $oferta->anio }}"
-                               class="form-control">
+                               name="año"
+                               id="año"
+                               value="{{ $oferta->año }}"
+                               class="form-control"
+                               min="2000"
+                               max="2099">
                     </div>
 
                     {{-- Fecha inicio --}}
@@ -67,13 +80,13 @@
                                class="form-control">
                     </div>
 
-                    {{-- Fecha final --}}
+                    {{-- Fecha fin --}}
                     <div class="form-group">
-                        <label for="fecha_final"><strong>Fecha final</strong></label>
+                        <label for="fecha_fin"><strong>Fecha fin</strong></label>
                         <input type="date"
-                               name="fecha_final"
-                               id="fecha_final"
-                               value="{{ $oferta->fecha_final }}"
+                               name="fecha_fin"
+                               id="fecha_fin"
+                               value="{{ $oferta->fecha_fin }}"
                                class="form-control">
                     </div>
 


### PR DESCRIPTION
- Corregir inyección de dependencias en CentroController (edit/update):
  * Cambiar parámetro de 'string \' a modelo 'Centro \'
  * Permitir que la policy reciba el objeto correcto para validación
  * Resolver problema de permisos negados al editar centros

- Sincronizar campos en formularios de ofertas con modelo:
  * Cambiar 'anio' por 'año' (nombre correcto en BD)
  * Cambiar 'fecha_final' por 'fecha_fin' (nombre correcto en BD)
  * Agregar campo 'centro_id' como selector (relación requerida)
  * Agregar límites de año (2000-2099) para mejor UX

- Actualizar OfertaController:
  * Importar modelo Centro
  * Pasar listado de centros a vistas create y edit
  * Poblamiento dinámico de selectores

- Corregir ruta en vista de edición de centros:
  * Cambiar 'centro.update' por 'centros.update'