### PR TITLE
manejo de recursos multimedia editables. Quiroz93

### DIFF
--- a/app/Services/MediaService.php
+++ b/app/Services/MediaService.php
@@ -4,11 +4,16 @@ namespace App\Services;
 
 use Illuminate\Http\UploadedFile;
 use Illuminate\Support\Facades\Storage;
+use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Str;
+use Intervention\Image\ImageManager;
+use Intervention\Image\Drivers\Gd\Driver as GdDriver;
+use Exception;
 
 class MediaService
 {
     protected string $disk = 'public';
+    protected ?ImageManager $imageManager = null;
     
     protected array $allowedImageMimes = [
         'image/jpeg',
@@ -22,6 +27,24 @@ class MediaService
         'video/webm',
         'video/ogg'
     ];
+
+    public function __construct()
+    {
+        // Initialize ImageManager only if image extension is available
+        try {
+            if (extension_loaded('gd')) {
+                $this->imageManager = new ImageManager(new GdDriver());
+            } elseif (extension_loaded('imagick')) {
+                $this->imageManager = new ImageManager(new \Intervention\Image\Drivers\Imagick\Driver());
+            } else {
+                $this->imageManager = null;
+                Log::warning('Neither GD nor Imagick PHP extensions are loaded - thumbnail generation will be disabled');
+            }
+        } catch (\Exception $e) {
+            $this->imageManager = null;
+            Log::error('Failed to initialize ImageManager: ' . $e->getMessage());
+        }
+    }
 
     /**
      * Procesar upload de archivo multimedia
@@ -48,10 +71,27 @@ class MediaService
         // 5. Generar metadata
         $metadata = $this->generateMetadata($file, $filePath, $type);
 
+        // 6. Intentar generar thumbnail para imágenes (NO para GIFs)
+        $thumbnailUrl = null;
+        if (($type === 'image') && !str_ends_with(strtolower($file->getClientOriginalName()), '.gif')) {
+            try {
+                $thumbnailPath = $this->generateThumbnail($filePath);
+                if ($thumbnailPath) {
+                    $thumbnailUrl = Storage::disk($this->disk)->url($thumbnailPath);
+                }
+            } catch (Exception $e) {
+                // Log error but don't fail upload
+                Log::warning("Thumbnail generation failed for {$filePath}: " . $e->getMessage());
+            }
+        }
+
+        $fileUrl = Storage::disk($this->disk)->url($filePath);
+
         return [
             'success' => true,
             'file_path' => $filePath,
-            'url' => Storage::disk($this->disk)->url($filePath),
+            'url' => $fileUrl,
+            'thumbnail_url' => $thumbnailUrl ?? $fileUrl,
             'metadata' => $metadata
         ];
     }
@@ -74,9 +114,11 @@ class MediaService
         $files = Storage::disk($this->disk)->files($path);
 
         return collect($files)->map(function ($file) use ($type) {
+            $fileUrl = Storage::disk($this->disk)->url($file);
+            
             $fileData = [
                 'path' => $file,
-                'url' => Storage::disk($this->disk)->url($file),
+                'url' => $fileUrl,
                 'name' => basename($file),
                 'size' => Storage::disk($this->disk)->size($file),
                 'modified' => Storage::disk($this->disk)->lastModified($file),
@@ -90,11 +132,11 @@ class MediaService
                     $fileData['thumbnail_url'] = Storage::disk($this->disk)->url($thumbPath);
                 } else {
                     // Si no existe thumbnail, usar imagen original como fallback
-                    $fileData['thumbnail_url'] = $fileData['url'];
+                    $fileData['thumbnail_url'] = $fileUrl;
                 }
             } elseif ($type === 'gif') {
                 // Para GIFs, siempre usar la URL original (mostrar animado)
-                $fileData['thumbnail_url'] = $fileData['url'];
+                $fileData['thumbnail_url'] = $fileUrl;
             }
 
             return $fileData;
@@ -127,26 +169,107 @@ class MediaService
      * @param string $filePath
      * @param int $width
      * @param int $height
-     * @return string|null (URL del thumbnail o null si error)
+     * @return string|null (ruta del thumbnail o null si error)
      */
     public function generateThumbnail(string $filePath, int $width = 200, int $height = 150): ?string
     {
-        // TODO: Implement thumbnail generation with proper Intervention\Image setup
-        // For now, return null - thumbnails will be implemented in future
-        return null;
+        // Si ImageManager no está disponible, no generar thumbnails
+        if ($this->imageManager === null) {
+            Log::debug('ImageManager not available - skipping thumbnail generation for ' . $filePath);
+            return null;
+        }
+
+        try {
+            $fullPath = Storage::disk($this->disk)->path($filePath);
+            
+            // Si el archivo no existe, retornar null
+            if (!file_exists($fullPath)) {
+                Log::error("Archivo para thumbnail no existe: {$fullPath}");
+                return null;
+            }
+
+            // Leer imagen con Intervention
+            $image = $this->imageManager->read($fullPath);
+
+            // Aplicar cover (crop desde el centro) y reducir calidad
+            $image->cover($width, $height, 'center')->quality(85);
+
+            // Generar ruta para el thumbnail
+            $thumbnailPath = $this->getThumbnailPath($filePath);
+            
+            // Crear directorio si no existe
+            $thumbnailDir = dirname(Storage::disk($this->disk)->path($thumbnailPath));
+            if (!is_dir($thumbnailDir)) {
+                mkdir($thumbnailDir, 0755, true);
+            }
+
+            // Guardar thumbnail
+            $fullThumbPath = Storage::disk($this->disk)->path($thumbnailPath);
+            $image->save($fullThumbPath);
+
+            Log::info("Thumbnail generado exitosamente: {$thumbnailPath}");
+            
+            return $thumbnailPath;
+        } catch (Exception $e) {
+            Log::error("Error generating thumbnail for {$filePath}: " . $e->getMessage());
+            return null;
+        }
     }
 
     /**
      * Generar poster para un video
      * 
      * @param string $filePath
-     * @return string|null (URL del poster o null si error)
+     * @return string|null (ruta del poster o null si error)
      */
     public function generateVideoPoster(string $filePath): ?string
     {
-        // TODO: Implement video poster generation with proper Intervention\Image setup
-        // For now, return null - video posters will be implemented in future
-        return null;
+        // Si ImageManager no está disponible, no generar posters
+        if ($this->imageManager === null) {
+            Log::debug('ImageManager not available - skipping poster generation for ' . $filePath);
+            return null;
+        }
+
+        try {
+            // Crear una imagen genérica de poster (320x180px)
+            $poster = $this->imageManager->create(320, 180)->fill('222222');
+
+            // Agregar un círculo de play (blanco) en el centro
+            $poster->circle(
+                radius: 40,
+                x: 160,
+                y: 90,
+                closure: function ($circle) {
+                    $circle->background('ffffff');
+                }
+            );
+
+            // Agregar triángulo de play (simulado con líneas)
+            // Crear un ícono simple de play
+            $poster->text('▶', 155, 85, closure: function ($text) {
+                $text->size(48)->color('222222')->align('center');
+            });
+
+            // Generar ruta para el poster
+            $posterPath = $this->getPosterPath($filePath);
+            
+            // Crear directorio si no existe
+            $posterDir = dirname(Storage::disk($this->disk)->path($posterPath));
+            if (!is_dir($posterDir)) {
+                mkdir($posterDir, 0755, true);
+            }
+
+            // Guardar poster
+            $fullPosterPath = Storage::disk($this->disk)->path($posterPath);
+            $poster->quality(85)->save($fullPosterPath);
+
+            Log::info("Video poster generado exitosamente: {$posterPath}");
+            
+            return $posterPath;
+        } catch (Exception $e) {
+            Log::error("Error generating video poster for {$filePath}: " . $e->getMessage());
+            return null;
+        }
     }
 
     // ============ Métodos Privados ============
@@ -244,7 +367,7 @@ class MediaService
             'file_size' => $file->getSize(),
             'mime_type' => $file->getMimeType(),
             'uploaded_at' => now()->toISOString(),
-            'uploaded_by' => auth()->id()
+            'uploaded_by' => auth()->check() ? auth()->id() : null
         ];
 
         // Agregar dimensiones para imágenes
@@ -261,5 +384,37 @@ class MediaService
         }
 
         return $metadata;
+    }
+
+    /**
+     * Obtener ruta del thumbnail para un archivo de imagen
+     * 
+     * @param string $filePath
+     * @return string
+     */
+    private function getThumbnailPath(string $filePath): string
+    {
+        // Reemplazar "media/images/" con "media/images/thumbnails/"
+        $parts = explode('/', $filePath);
+        array_splice($parts, -1, 0, 'thumbnails');
+        return implode('/', $parts);
+    }
+
+    /**
+     * Obtener ruta del poster para un archivo de video
+     * 
+     * @param string $filePath
+     * @return string
+     */
+    private function getPosterPath(string $filePath): string
+    {
+        // Reemplazar "media/videos/" con "media/videos/posters/"
+        // y cambiar extensión a .png
+        $parts = explode('/', $filePath);
+        $filename = array_pop($parts);
+        $filename = pathinfo($filename, PATHINFO_FILENAME) . '.png';
+        array_splice($parts, -1, 0, 'posters');
+        $parts[] = $filename;
+        return implode('/', $parts);
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
     "license": "MIT",
     "require": {
         "php": "^8.2",
-        "intervention/image": "^3.11",
+        "intervention/image": "3.3",
         "jeroennoten/laravel-adminlte": "^3.15",
         "laravel/framework": "^12.0",
         "laravel/tinker": "^2.10.1",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "37a3d4e39db97e5c7ceb5ab887cd4667",
+    "content-hash": "a4d4c15b82f339c13c29b123cc372e7c",
     "packages": [
         {
             "name": "almasaeed2010/adminlte",
@@ -1165,28 +1165,27 @@
         },
         {
             "name": "intervention/image",
-            "version": "3.11.6",
+            "version": "3.3.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Intervention/image.git",
-                "reference": "5f6d27d9fd56312c47f347929e7ac15345c605a1"
+                "reference": "d37e47ba5fa0844a146dbdfee75b1b29f5eb5324"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Intervention/image/zipball/5f6d27d9fd56312c47f347929e7ac15345c605a1",
-                "reference": "5f6d27d9fd56312c47f347929e7ac15345c605a1",
+                "url": "https://api.github.com/repos/Intervention/image/zipball/d37e47ba5fa0844a146dbdfee75b1b29f5eb5324",
+                "reference": "d37e47ba5fa0844a146dbdfee75b1b29f5eb5324",
                 "shasum": ""
             },
             "require": {
                 "ext-mbstring": "*",
-                "intervention/gif": "^4.2",
+                "intervention/gif": "^4",
                 "php": "^8.1"
             },
             "require-dev": {
                 "mockery/mockery": "^1.6",
-                "phpstan/phpstan": "^2.1",
-                "phpunit/phpunit": "^10.0 || ^11.0 || ^12.0",
-                "slevomat/coding-standard": "~8.0",
+                "phpstan/phpstan": "^1",
+                "phpunit/phpunit": "^9",
                 "squizlabs/php_codesniffer": "^3.8"
             },
             "suggest": {
@@ -1206,11 +1205,11 @@
                 {
                     "name": "Oliver Vogel",
                     "email": "oliver@intervention.io",
-                    "homepage": "https://intervention.io"
+                    "homepage": "https://intervention.io/"
                 }
             ],
-            "description": "PHP Image Processing",
-            "homepage": "https://image.intervention.io",
+            "description": "PHP image manipulation",
+            "homepage": "https://image.intervention.io/",
             "keywords": [
                 "gd",
                 "image",
@@ -1221,7 +1220,7 @@
             ],
             "support": {
                 "issues": "https://github.com/Intervention/image/issues",
-                "source": "https://github.com/Intervention/image/tree/3.11.6"
+                "source": "https://github.com/Intervention/image/tree/3.3.0"
             },
             "funding": [
                 {
@@ -1231,13 +1230,9 @@
                 {
                     "url": "https://github.com/Intervention",
                     "type": "github"
-                },
-                {
-                    "url": "https://ko-fi.com/interventionphp",
-                    "type": "ko_fi"
                 }
             ],
-            "time": "2025-12-17T13:38:29+00:00"
+            "time": "2024-01-20T08:50:30+00:00"
         },
         {
             "name": "jeroennoten/laravel-adminlte",

--- a/resources/views/home.blade.php
+++ b/resources/views/home.blade.php
@@ -64,12 +64,16 @@
 
 {{-- Encabezado principal --}}
 <div class="container" >
+  @php
+    $heroBgPath = getCustomContent('home', 'hero_background', null);
+    $heroBgUrl = $heroBgPath ? asset('storage/' . $heroBgPath) : asset('images/background_1.png');
+  @endphp
   <div class="p-4 p-md-5 mb-4 rounded text-body-emphasis editable" 
        data-model="home" 
        data-model-id="0" 
        data-key="hero_background" 
        data-type="image"
-       style="background-image: url('{!! getCustomContent('home', 'hero_background', '/images/background_1.png') !!}'); background-size:cover">
+       style="background-image: url('{{ $heroBgUrl }}'); background-size:cover">
     <div class="row">
       <div class="col-lg-6 px-0" >
       <h1 class="display-4 text-bold editable" style="color: #39A900; font-family: 'worksans sans-serif'; font-style:italic;"
@@ -104,7 +108,11 @@
     </div>
     <div class="carousel-inner">
       <div class="carousel-item active">
-        <img src="{!! getCustomContent('home', 'carousel_slide1_image', '...') !!}" class="d-block w-100 editable" alt="Slide 1"
+        @php
+          $slide1ImagePath = getCustomContent('home', 'carousel_slide1_image', null);
+          $slide1ImageUrl = $slide1ImagePath ? asset('storage/' . $slide1ImagePath) : asset('images/carousel-placeholder.jpg');
+        @endphp
+        <img src="{{ $slide1ImageUrl }}" class="d-block w-100 editable" alt="Slide 1"
              data-model="home" data-model-id="0" data-key="carousel_slide1_image" data-type="image">
         <div class="carousel-caption d-none d-md-block">
           <h5 class="editable" data-model="home" data-model-id="0" data-key="carousel_slide1_title" data-type="text">
@@ -116,7 +124,11 @@
         </div>
       </div>
       <div class="carousel-item">
-        <img src="{!! getCustomContent('home', 'carousel_slide2_image', '...') !!}" class="d-block w-100 editable" alt="Slide 2"
+        @php
+          $slide2ImagePath = getCustomContent('home', 'carousel_slide2_image', null);
+          $slide2ImageUrl = $slide2ImagePath ? asset('storage/' . $slide2ImagePath) : asset('images/carousel-placeholder.jpg');
+        @endphp
+        <img src="{{ $slide2ImageUrl }}" class="d-block w-100 editable" alt="Slide 2"
              data-model="home" data-model-id="0" data-key="carousel_slide2_image" data-type="image">
         <div class="carousel-caption d-none d-md-block">
           <h5 class="editable" data-model="home" data-model-id="0" data-key="carousel_slide2_title" data-type="text">
@@ -128,7 +140,11 @@
         </div>
       </div>
       <div class="carousel-item">
-        <img src="{!! getCustomContent('home', 'carousel_slide3_image', '...') !!}" class="d-block w-100 editable" alt="Slide 3"
+        @php
+          $slide3ImagePath = getCustomContent('home', 'carousel_slide3_image', null);
+          $slide3ImageUrl = $slide3ImagePath ? asset('storage/' . $slide3ImagePath) : asset('images/carousel-placeholder.jpg');
+        @endphp
+        <img src="{{ $slide3ImageUrl }}" class="d-block w-100 editable" alt="Slide 3"
              data-model="home" data-model-id="0" data-key="carousel_slide3_image" data-type="image">
         <div class="carousel-caption d-none d-md-block">
           <h5 class="editable" data-model="home" data-model-id="0" data-key="carousel_slide3_title" data-type="text">

--- a/resources/views/public/ofertas/index.blade.php
+++ b/resources/views/public/ofertas/index.blade.php
@@ -4,20 +4,25 @@
 
 @section('content')
 
-{{-- ===================== --}}
-{{-- Banner principal --}}
-{{-- ===================== --}}
-<section class="bg-ligth text-white position-relative" style="font-family: 'worksans sans-serif';">
 
-    <img src="{{ asset('images/oferta4.jpeg') }}"
-         class="w-100 position-absolute top-0 start-0 h-100 object-fit-cover opacity-50 editable"
-         data-model="oferta"
-         data-model-id="0"
-         data-key="banner_image"
-         data-type="image"
-         alt="Oferta educativa CATA">
+{{-- Banner principal --}}
+<section class="bg-ligth text-white position-relative" style="font-family: 'worksans sans-serif';">
+    @can('public_content.edit')
+    <div class="alert alert-info">
+        Modo edición activado - Haz clic en cualquier elemento editable
+    </div>
+    @endcan
 
     <div class="container position-relative py-5 text-dark">
+        <div>
+            <img src="{{ getCustomContent('oferta', 'banner_image', asset('images/oferta4.jpeg')) }}"
+                class="w-100 position-absolute top-0 start-0 h-100 object-fit-cover opacity-50 editable"
+                data-model="oferta"
+                data-model-id="0"
+                data-key="banner_image"
+                data-type="image"
+                alt="Oferta educativa CATA">
+        </div>
         <div class="row">
             <div class="col-lg-8">
 
@@ -50,15 +55,9 @@
     </div>
 </section>
 
-@can('public_content.edit')
-    <div class="alert alert-info">
-        Modo edición activado - Haz clic en cualquier elemento editable
-    </div>
-@endcan
 
-{{-- ===================== --}}
+
 {{-- Sección motivacional --}}
-{{-- ===================== --}}
 <section class="py-5 bg-light" style="font-family: 'worksans sans-serif';">
     <div class="container text-center">
 
@@ -82,9 +81,7 @@
     </div>
 </section>
 
-{{-- ===================== --}}
-{{-- Listado de ofertas --}}
-{{-- ===================== --}}
+{{-- listado de ofertas --}}
 <section class="py-5" style="font-family: 'worksans sans-serif';">
     <div class="container">
 
@@ -98,10 +95,10 @@
                     {{ getCustomContent('oferta', 'oferta_title', 'Ofertas Educativas Disponibles') }}
                 </h2>
                 <p class="text-muted editable"
-                data-model="oferta"
-                data-model-id="0"
-                data-key="oferta_text"
-                data-type="text">
+                    data-model="oferta"
+                    data-model-id="0"
+                    data-key="oferta_text"
+                    data-type="text">
                     {{ getCustomContent('oferta', 'oferta_text', 'Conoce nuestras oportunidades de formación vigentes') }}
                 </p>
             </div>
@@ -115,11 +112,20 @@
                 <div class="card h-100 shadow-sm border-0">
 
                     {{-- Imagen de la oferta --}}
-                    <img src="{{ $oferta->custom('imagen')
-                            ? asset('storage/' . $oferta->custom('imagen'))
-                            : asset('images/ofertas/default.jpg') }}"
-                        class="card-img-top"
-                        alt="{{ $oferta->nombre }}">
+                    @php
+                        $imagenPath = $oferta->custom('imagen');
+                        $imagenUrl = $imagenPath 
+                            ? asset('storage/' . $imagenPath)
+                            : asset('images/ofertas/default.jpg');
+                    @endphp
+                    <img src="{{ $imagenUrl }}"
+                        class="card-img-top editable"
+                        data-model="oferta"
+                        data-model-id="{{ $oferta->id }}"
+                        data-key="imagen"
+                        data-type="image"
+                        alt="{{ $oferta->nombre }}"
+                        style="height: 250px; object-fit: cover;">
 
                     <div class="card-body d-flex flex-column">
 
@@ -167,9 +173,8 @@
     </div>
 </section>
 
-{{-- ===================== --}}
+
 {{-- Banner inferior --}}
-{{-- ===================== --}}
 <section class="py-5 bg-primary text-white" style="font-family: 'worksans sans-serif';">
     <div class="container text-center">
 

--- a/resources/views/public/ofertas/index.blade.php
+++ b/resources/views/public/ofertas/index.blade.php
@@ -14,8 +14,15 @@
     @endcan
 
     <div class="container position-relative py-5 text-dark">
+        {{-- Banner background image --}}
+        @php
+            $bannerImagePath = getCustomContent('oferta', 'banner_image', null);
+            $bannerImageUrl = $bannerImagePath 
+                ? asset('storage/' . $bannerImagePath)
+                : asset('images/oferta4.jpeg');
+        @endphp
         <div>
-            <img src="{{ getCustomContent('oferta', 'banner_image', asset('images/oferta4.jpeg')) }}"
+            <img src="{{ $bannerImageUrl }}"
                 class="w-100 position-absolute top-0 start-0 h-100 object-fit-cover opacity-50 editable"
                 data-model="oferta"
                 data-model-id="0"


### PR DESCRIPTION
- Instalado intervention/image:3.3 con soporte para GD e Imagick
- Reescrito servicio MediaService.php con:
  * Inicialización inteligente de ImageManager con fallback automático
  * Generación de thumbnails (200x150px, quality 85%, center-cropped)
  * Generación de posters para videos (320x180px con ícono de play)
  * Procesamiento seguro de GIFs (sin compresión para preservar animación)
  * Logging comprehensivo para debugging
  * Degradación elegante cuando librerías de imagen no están disponibles
- Estructura de almacenamiento organizada:
  * Thumbnails en: media/images/{category}/thumbnails/
  * Posters en: media/videos/{category}/posters/
  * Archivos originales en: media/{type}/{category}/
- Retorna URLs de thumbnails en respuestas de upload
- Compatible con Laravel 12.x y PHP 8.2+

BREAKING CHANGE: MediaService ahora requiere Intervention\Image para funcionalidad completa
(aunque fallback automático permite funcionar sin librerías de imagen)
- Soluciona problema donde las imágenes desaparecían al recargar la página
- Optimiza la construcción de URL de imágenes evitando llamadas duplicadas a custom()
- Agrega estilo height y object-fit para uniformidad visual en las tarjetas
- Las imágenes ahora persisten correctamente en la base de datos
- Se aplicó el patrón de optimización de URLs de imágenes en todas las secciones que cargan contenido multimedia editable:

Home (home.blade.php):
- Hero section background image (hero_background)
- 3 imágenes de carousel (carousel_slide1/2/3_image)

Ofertas públicas (public/ofertas/index.blade.php):
- Banner principal (banner_image)

Cambios aplicados:
- Evitar llamadas duplicadas a getCustomContent()
- Construir URLs correctamente usando asset('storage/' . path)
- Mejorar fallback a imágenes por defecto
- Mantener compatibilidad con sistema editable existente
- Downgrade intervention/image: 3.11.6 -> 3.3.0
- Update intervention/gif constraint: ^4.2 -> ^4
- Downgrade phpstan/phpstan: ^2.1 -> ^1
- Downgrade phpunit/phpunit: ^10.0|^11.0|^12.0 -> ^9
- Remove slevomat/coding-standard dependency
- Update package metadata and homepage URLs
- Mantiene la versión local con sistema editable de contenido
- Preserva carga dinámica de imágenes de fondo via getCustomContent()
- Asegura funcionamiento del módulo de tratamiento de multimedia
- Resuelve conflicto merge manteniendo todas las características del sistema