### PR TITLE
modulo de respaldo de información de preinscritos. Quiroz93

### DIFF
--- a/app/Http/Controllers/Admin/EstadisticasPreinscritosController.php
+++ b/app/Http/Controllers/Admin/EstadisticasPreinscritosController.php
@@ -54,6 +54,7 @@ class EstadisticasPreinscritosController extends Controller
 
         // Inscritos, faltantes y rechazados por programa
         // Agrupar por programa y estado
+
         $estadosPorPrograma = Preinscrito::select('programa_id', 'estado', DB::raw('count(*) as total'))
             ->groupBy('programa_id', 'estado')
             ->get();
@@ -64,8 +65,22 @@ class EstadisticasPreinscritosController extends Controller
         foreach ($estadosPorPrograma as $row) {
             if ($row->estado === 'inscrito') {
                 $inscritosPorPrograma[$row->programa_id] = $row->total;
-            } elseif ($row->estado === 'rechazado') {
-                $rechazadosPorPrograma[$row->programa_id] = $row->total;
+            }
+        }
+
+        // Sumar rechazados desde preinscritos_rechazados
+        $rechazadosPorPrograma = [];
+        $rechazadosRaw = \DB::table('preinscritos_rechazados')
+            ->select('programa', DB::raw('count(*) as total'))
+            ->groupBy('programa')
+            ->get();
+        // Mapear nombre de programa a id si existe en la tabla programas
+        $programasNombreToId = Programa::pluck('id', 'nombre');
+        foreach ($rechazadosRaw as $row) {
+            $programaNombre = $row->programa;
+            $programaId = $programasNombreToId[$programaNombre] ?? null;
+            if ($programaId) {
+                $rechazadosPorPrograma[$programaId] = $row->total;
             }
         }
 

--- a/app/Http/Controllers/Admin/EstadisticasPreinscritosController.php
+++ b/app/Http/Controllers/Admin/EstadisticasPreinscritosController.php
@@ -1,0 +1,104 @@
+<?php
+namespace App\Http\Controllers\Admin;
+
+use App\Http\Controllers\Controller;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Gate;
+use App\Models\Preinscrito;
+use App\Models\Programa;
+use Illuminate\Support\Facades\DB;
+use Carbon\Carbon;
+
+class EstadisticasPreinscritosController extends Controller
+{
+    public function index(Request $request)
+    {
+        Gate::authorize('preinscritos.estadisticas.view');
+
+        // KPIs principales
+        $total = Preinscrito::count();
+        $porEstado = Preinscrito::select('estado', DB::raw('count(*) as total'))
+            ->groupBy('estado')->pluck('total', 'estado');
+        $porPrograma = Preinscrito::select('programa_id', DB::raw('count(*) as total'))
+            ->groupBy('programa_id')->pluck('total', 'programa_id');
+        $programasFicha = Programa::whereIn('id', $porPrograma->keys())->pluck('numero_ficha', 'id');
+        $programasNombre = Programa::whereIn('id', $porPrograma->keys())->pluck('nombre', 'id');
+
+        // Novedades (corregido: contar estado 'con_novedad')
+        $conNovedad = Preinscrito::where('estado', 'con_novedad')->count();
+        // Novedades resueltas: contar novedades con estado 'resuelta'
+        $novedadResuelta = \App\Models\NovedadPreinscrito::where('estado', 'resuelta')->count();
+
+        // Evolución mensual (últimos 12 meses)
+        $evolucion = Preinscrito::select(
+                DB::raw('DATE_FORMAT(created_at, "%Y-%m") as mes'),
+                DB::raw('count(*) as total')
+            )
+            ->where('created_at', '>=', Carbon::now()->subMonths(12))
+            ->groupBy('mes')
+            ->orderBy('mes')
+            ->pluck('total', 'mes');
+
+        // Top 10 programas con más preinscritos
+        $topProgramas = Preinscrito::select('programa_id', DB::raw('count(*) as total'))
+            ->groupBy('programa_id')
+            ->orderByDesc('total')
+            ->take(10)
+            ->get()
+            ->map(function($row) use ($programasNombre) {
+                return [
+                    'programa' => $programasNombre[$row->programa_id] ?? 'N/A',
+                    'total' => $row->total
+                ];
+            });
+
+        // Inscritos, faltantes y rechazados por programa
+        // Agrupar por programa y estado
+        $estadosPorPrograma = Preinscrito::select('programa_id', 'estado', DB::raw('count(*) as total'))
+            ->groupBy('programa_id', 'estado')
+            ->get();
+
+        $inscritosPorPrograma = [];
+        $rechazadosPorPrograma = [];
+        $faltantesPorPrograma = [];
+        foreach ($estadosPorPrograma as $row) {
+            if ($row->estado === 'inscrito') {
+                $inscritosPorPrograma[$row->programa_id] = $row->total;
+            } elseif ($row->estado === 'rechazado') {
+                $rechazadosPorPrograma[$row->programa_id] = $row->total;
+            }
+        }
+
+        // Faltantes: cupos - inscritos
+        $cuposPorPrograma = Programa::pluck('cupos', 'id');
+        $faltantesPorPrograma = [];
+        foreach ($cuposPorPrograma as $id => $cupos) {
+            $faltantesPorPrograma[$id] = max(0, ($cupos ?? 0) - ($inscritosPorPrograma[$id] ?? 0));
+        }
+
+        $kpis['grafica_programas'] = [
+            'labels' => $programasFicha->values()->toArray(),
+            'nombres' => $programasNombre->values()->toArray(),
+            'inscritos' => [],
+            'faltantes' => [],
+            'rechazados' => [],
+        ];
+        foreach ($programasFicha as $id => $ficha) {
+            $kpis['grafica_programas']['inscritos'][] = $inscritosPorPrograma[$id] ?? 0;
+            $kpis['grafica_programas']['faltantes'][] = $faltantesPorPrograma[$id] ?? 0;
+            $kpis['grafica_programas']['rechazados'][] = $rechazadosPorPrograma[$id] ?? 0;
+        }
+
+        $kpis = array_merge([
+            'total' => $total,
+            'por_estado' => $porEstado,
+            'por_programa' => $porPrograma,
+            'con_novedad' => $conNovedad,
+            'novedad_resuelta' => $novedadResuelta,
+            'evolucion' => $evolucion,
+            'top_programas' => $topProgramas,
+        ], $kpis);
+
+        return view('admin.estadisticas.index', compact('kpis', 'programasFicha'));
+    }
+}

--- a/app/Http/Controllers/Admin/PreinscritosHistoricoController.php
+++ b/app/Http/Controllers/Admin/PreinscritosHistoricoController.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace App\Http\Controllers\Admin;
+
+use App\Http\Controllers\Controller;
+use Illuminate\Http\Request;
+use App\Models\Preinscrito;
+use Illuminate\Support\Facades\DB;
+
+class PreinscritosHistoricoController extends Controller
+{
+    public function respaldarYLimpiar(Request $request)
+    {
+        $request->validate([
+            'oferta_id' => 'required|exists:ofertas,id',
+        ]);
+
+        DB::transaction(function () use ($request) {
+            $preinscritos = Preinscrito::all();
+            $historico = $preinscritos->map(function ($item) use ($request) {
+                $data = $item->toArray();
+                $data['oferta_id'] = $request->oferta_id;
+                unset($data['id']);
+                unset($data['deleted_at']);
+                // Convertir fechas ISO8601 a formato MySQL si es necesario
+                foreach (['created_at', 'updated_at', 'fecha_resolucion'] as $campo) {
+                    if (isset($data[$campo]) && $data[$campo]) {
+                        // Si es string tipo 2026-02-08T00:39:40.000000Z, convertir a Y-m-d H:i:s
+                        if (is_string($data[$campo]) && str_contains($data[$campo], 'T')) {
+                            $data[$campo] = date('Y-m-d H:i:s', strtotime($data[$campo]));
+                        }
+                    }
+                }
+                return $data;
+            })->toArray();
+            if (count($historico)) {
+                DB::table('preinscritos_historico')->insert($historico);
+            }
+            // Eliminar novedades primero para evitar error de clave foránea
+            DB::table('novedades_preinscritos')->delete();
+            Preinscrito::query()->delete();
+        });
+
+        return redirect()->back()->with('success', 'Preinscritos respaldados y limpiados correctamente.');
+    }
+}

--- a/app/Http/Controllers/Admin/ProgramaController.php
+++ b/app/Http/Controllers/Admin/ProgramaController.php
@@ -19,7 +19,24 @@ class ProgramaController extends \App\Http\Controllers\Controller
     public function index()
     {
         Gate::authorize('programas.view');
-        $programas = Programa::all();
+        $query = Programa::query();
+
+        // Filtro por red tecnológica
+        if (request('red')) {
+            $query->where('red_id', request('red'));
+        }
+
+        // Filtro por nombre
+        if (request('nombre')) {
+            $query->where('nombre', 'like', '%' . request('nombre') . '%');
+        }
+
+        // Filtro por número de ficha
+        if (request('ficha')) {
+            $query->where('numero_ficha', 'like', '%' . request('ficha') . '%');
+        }
+
+        $programas = $query->get();
         return view('admin.programas.index', compact('programas'));
     }
 

--- a/app/Models/PreinscritosHistorico.php
+++ b/app/Models/PreinscritosHistorico.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+class PreinscritosHistorico extends Model
+{
+    protected $table = 'preinscritos_historico';
+    protected $fillable = [
+        'nombres',
+        'apellidos',
+        'tipo_documento',
+        'numero_documento',
+        'celular_principal',
+        'celular_alternativo',
+        'correo_principal',
+        'correo_alternativo',
+        'programa_id',
+        'estado',
+        'comentarios',
+        'created_by',
+        'updated_by',
+        'oferta_id',
+    ];
+}

--- a/database/migrations/2026_02_11_añadir_fk_preinscrito_id_a_rechazados.php
+++ b/database/migrations/2026_02_11_añadir_fk_preinscrito_id_a_rechazados.php
@@ -1,0 +1,25 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    public function up()
+    {
+        Schema::table('preinscritos_rechazados', function (Blueprint $table) {
+            $table->unsignedBigInteger('preinscrito_id')->nullable()->after('id');
+            $table->foreign('preinscrito_id')
+                ->references('id')->on('preinscritos')
+                ->onDelete('set null');
+        });
+    }
+
+    public function down()
+    {
+        Schema::table('preinscritos_rechazados', function (Blueprint $table) {
+            $table->dropForeign(['preinscrito_id']);
+            $table->dropColumn('preinscrito_id');
+        });
+    }
+};

--- a/database/migrations/2026_02_11_normalizar_preinscritos_rechazados.php
+++ b/database/migrations/2026_02_11_normalizar_preinscritos_rechazados.php
@@ -1,0 +1,27 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    public function up()
+    {
+        Schema::table('preinscritos_rechazados', function (Blueprint $table) {
+            $table->unsignedBigInteger('programa_id')->nullable()->after('programa');
+            $table->foreign('programa_id')
+                ->references('id')->on('programas')
+                ->onDelete('set null');
+            $table->string('nombres')->nullable()->after('nombre_completo');
+            $table->string('apellidos')->nullable()->after('nombres');
+        });
+    }
+
+    public function down()
+    {
+        Schema::table('preinscritos_rechazados', function (Blueprint $table) {
+            $table->dropForeign(['programa_id']);
+            $table->dropColumn(['programa_id', 'nombres', 'apellidos']);
+        });
+    }
+};

--- a/database/migrations/2026_02_12_045120_create_preinscritos_historico_table.php
+++ b/database/migrations/2026_02_12_045120_create_preinscritos_historico_table.php
@@ -1,0 +1,53 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('preinscritos_historico', function (Blueprint $table) {
+            $table->id();
+            // Datos personales
+            $table->string('nombres');
+            $table->string('apellidos');
+            // Documento
+            $table->enum('tipo_documento', ['cc', 'ti', 'ce', 'ppt', 'pa', 'pep', 'nit']);
+            $table->string('numero_documento')->index();
+            // Contacto
+            $table->string('celular_principal');
+            $table->string('celular_alternativo')->nullable();
+            $table->string('correo_principal');
+            $table->string('correo_alternativo')->nullable();
+            // Relación con Programa
+            $table->unsignedBigInteger('programa_id');
+            $table->foreign('programa_id')->references('id')->on('programas')->onDelete('cascade');
+            // Estado del preinscrito
+            $table->enum('estado', ['inscrito', 'por_inscribir', 'con_novedad'])->default('por_inscribir');
+            // Información adicional
+            $table->text('comentarios')->nullable();
+            // Auditoría
+            $table->unsignedBigInteger('created_by')->nullable();
+            $table->unsignedBigInteger('updated_by')->nullable();
+            $table->foreign('created_by')->references('id')->on('users')->onDelete('set null');
+            $table->foreign('updated_by')->references('id')->on('users')->onDelete('set null');
+            // Oferta asociada
+            $table->unsignedBigInteger('oferta_id');
+            $table->foreign('oferta_id')->references('id')->on('ofertas')->onDelete('cascade');
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('preinscritos_historico');
+    }
+};

--- a/database/migrations/2026_02_12_añadir_campos_faltantes_a_preinscritos_historico.php
+++ b/database/migrations/2026_02_12_añadir_campos_faltantes_a_preinscritos_historico.php
@@ -1,0 +1,27 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    public function up()
+    {
+        Schema::table('preinscritos_historico', function (Blueprint $table) {
+            $table->string('novedades')->nullable();
+            $table->string('tipo_novedad')->nullable();
+            $table->boolean('novedad_resuelta')->default(false);
+            $table->timestamp('fecha_resolucion')->nullable();
+            $table->unsignedBigInteger('resuelto_por')->nullable();
+            $table->foreign('resuelto_por')->references('id')->on('users')->nullOnDelete();
+        });
+    }
+
+    public function down()
+    {
+        Schema::table('preinscritos_historico', function (Blueprint $table) {
+            $table->dropForeign(['resuelto_por']);
+            $table->dropColumn(['novedades', 'tipo_novedad', 'novedad_resuelta', 'fecha_resolucion', 'resuelto_por']);
+        });
+    }
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,7 +5,8 @@
     "packages": {
         "": {
             "dependencies": {
-                "bootstrap": "^5.3.8"
+                "bootstrap": "^5.3.8",
+                "chart.js": "^4.5.1"
             },
             "devDependencies": {
                 "axios": "^1.11.0",
@@ -507,6 +508,12 @@
                 "@jridgewell/sourcemap-codec": "^1.4.14"
             }
         },
+        "node_modules/@kurkle/color": {
+            "version": "0.3.4",
+            "resolved": "https://registry.npmjs.org/@kurkle/color/-/color-0.3.4.tgz",
+            "integrity": "sha512-M5UknZPHRu3DEDWoipU6sE8PdkZ6Z/S+v4dD+Ke8IaNlpdSQah50lz1KtcFBa2vsdOnwbbnxJwVM4wty6udA5w==",
+            "license": "MIT"
+        },
         "node_modules/@popperjs/core": {
             "version": "2.11.8",
             "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.8.tgz",
@@ -959,6 +966,18 @@
             },
             "engines": {
                 "node": ">=8"
+            }
+        },
+        "node_modules/chart.js": {
+            "version": "4.5.1",
+            "resolved": "https://registry.npmjs.org/chart.js/-/chart.js-4.5.1.tgz",
+            "integrity": "sha512-GIjfiT9dbmHRiYi6Nl2yFCq7kkwdkp1W/lp2J99rX0yo9tgJGn3lKQATztIjb5tVtevcBtIdICNWqlq5+E8/Pw==",
+            "license": "MIT",
+            "dependencies": {
+                "@kurkle/color": "^0.3.0"
+            },
+            "engines": {
+                "pnpm": ">=8"
             }
         },
         "node_modules/cliui": {

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
         "vite": "^7.0.7"
     },
     "dependencies": {
-        "bootstrap": "^5.3.8"
+        "bootstrap": "^5.3.8",
+        "chart.js": "^4.5.1"
     }
 }

--- a/resources/js/admin/admin.js
+++ b/resources/js/admin/admin.js
@@ -38,6 +38,7 @@ document.addEventListener('DOMContentLoaded', function() {
         }, 3000);
     });
 
+
     // DataTables initialization with Spanish
     if (typeof $.fn.dataTable !== 'undefined') {
         $('.data-table').DataTable({

--- a/resources/js/admin/estadisticas.js
+++ b/resources/js/admin/estadisticas.js
@@ -1,0 +1,132 @@
+import Chart from 'chart.js/auto';
+// Gráfico comparativo de inscritos, faltantes y rechazados por programa
+const comparativoData = window.estadisticas?.grafica_programas || {};
+const ctxComparativo = document.getElementById('graficoComparativoProgramas');
+if (ctxComparativo && comparativoData.labels && comparativoData.labels.length) {
+    new Chart(ctxComparativo, {
+        type: 'bar',
+        data: {
+            labels: comparativoData.labels,
+            datasets: [
+                {
+                    label: 'Inscritos',
+                    data: comparativoData.inscritos,
+                    backgroundColor: '#39a900', // Verde SENA
+                },
+                {
+                    label: 'Faltantes',
+                    data: comparativoData.faltantes,
+                    backgroundColor: '#9ec1d4', // Azul oscuro SENA
+                },
+                {
+                    label: 'Rechazados',
+                    data: comparativoData.rechazados,
+                    backgroundColor: '#ff6600', // Naranja fuerte
+                }
+            ]
+        },
+        options: {
+            responsive: true,
+            plugins: {
+                legend: { position: 'top' },
+                title: { display: false },
+                tooltip: {
+                    callbacks: {
+                        title: function(context) {
+                            const idx = context[0].dataIndex;
+                            if (comparativoData.nombres && comparativoData.nombres[idx]) {
+                                return comparativoData.nombres[idx];
+                            }
+                            return context[0].label;
+                        }
+                    }
+                }
+            },
+            scales: {
+                x: { stacked: true },
+                y: { stacked: true, beginAtZero: true }
+            }
+        }
+    });
+}
+
+
+document.addEventListener('DOMContentLoaded', function () {
+    // Gráfico de evolución mensual
+    const evolucionData = window.estadisticas?.evolucion || {};
+    const ctxEvolucion = document.getElementById('graficoEvolucion');
+    if (ctxEvolucion && Object.keys(evolucionData).length) {
+        new Chart(ctxEvolucion, {
+            type: 'line',
+            data: {
+                labels: Object.keys(evolucionData),
+                datasets: [{
+                    label: 'Preinscritos',
+                    data: Object.values(evolucionData),
+                    borderColor: '#39a900',
+                    backgroundColor: 'rgba(57,169,0,0.1)',
+                    fill: true,
+                    tension: 0.3
+                }]
+            },
+            options: {
+                responsive: true,
+                plugins: {
+                    legend: { display: false },
+                    title: { display: false }
+                }
+            }
+        });
+    }
+
+    // Gráfico de estados
+    const estadosData = window.estadisticas?.por_estado || {};
+    const ctxEstados = document.getElementById('graficoEstados');
+    if (ctxEstados && Object.keys(estadosData).length) {
+        new Chart(ctxEstados, {
+            type: 'doughnut',
+            data: {
+                labels: Object.keys(estadosData),
+                datasets: [{
+                    data: Object.values(estadosData),
+                    backgroundColor: ['#39a900', '#ffc107', '#dc3545', '#0d6efd', '#6c757d'],
+                }]
+            },
+            options: {
+                responsive: true,
+                plugins: {
+                    legend: { position: 'bottom' },
+                    title: { display: false }
+                }
+            }
+        });
+    }
+
+    // Gráfico de programas
+    const programasData = window.estadisticas?.por_programa || {};
+    const ctxProgramas = document.getElementById('graficoProgramas');
+    if (ctxProgramas && Object.keys(programasData).length) {
+        new Chart(ctxProgramas, {
+            type: 'bar',
+            data: {
+                labels: Object.keys(programasData),
+                datasets: [{
+                    label: 'Preinscritos',
+                    data: Object.values(programasData),
+                    backgroundColor: '#39a900',
+                }]
+            },
+            options: {
+                responsive: true,
+                plugins: {
+                    legend: { display: false },
+                    title: { display: false }
+                },
+                scales: {
+                    x: { beginAtZero: true },
+                    y: { beginAtZero: true }
+                }
+            }
+        });
+    }
+});

--- a/resources/views/admin/dashboard.blade.php
+++ b/resources/views/admin/dashboard.blade.php
@@ -22,6 +22,83 @@
 <div class="container-fluid">
     <div class="row">
 
+    {{-- Preinscritos --}}
+    @can('preinscritos.view')
+    <div class="col-md-4 mt-4">
+        <div class="card text-center shadow-sm">
+            <div class="card-header">
+                <i class="fas fa-user-check fa-3x"></i>
+            </div>
+            <div class="card-body">
+                <h5 class="card-title">Preinscritos</h5>
+                <a href="{{ route('preinscritos.index') }}" class="btn btn-outline-success btn-sm mt-3">
+                    Gestionar preinscritos
+                </a>
+                <a href="{{ route('preinscritos.reportes') }}" class="btn btn-outline-info btn-sm mt-3 ms-2">
+                    Reportes
+                </a>
+                <a href="{{ route('preinscritos.historial-exportaciones') }}" class="btn btn-outline-secondary btn-sm mt-3 ms-2">
+                    Historial de exportaciones
+                </a>
+                <a href="{{ route('preinscritos.consolidaciones.index') }}" class="btn btn-outline-primary btn-sm mt-3 ms-2">
+                    Consolidaciones
+                </a>
+            </div>
+        </div>
+    </div>
+    @endcan
+
+    {{-- Programa Detalles --}}
+    @can('programa_detalles.view')
+    <div class="col-md-4 mt-4">
+        <div class="card text-center shadow-sm">
+            <div class="card-header">
+                <i class="fas fa-info-circle fa-3x"></i>
+            </div>
+            <div class="card-body">
+                <h5 class="card-title">Detalles de Programas</h5>
+                <a href="{{ route('programa_detalles.index') }}" class="btn btn-outline-warning btn-sm mt-3">
+                    Gestionar detalles
+                </a>
+            </div>
+        </div>
+    </div>
+    @endcan
+
+    {{-- Novedades (tipos) --}}
+    @can('novedades_tipos.view')
+    <div class="col-md-4 mt-4">
+        <div class="card text-center shadow-sm">
+            <div class="card-header">
+                <i class="fas fa-exclamation-circle fa-3x"></i>
+            </div>
+            <div class="card-body">
+                <h5 class="card-title">Tipos de Novedades</h5>
+                <a href="{{ route('novedades.tipos.index') }}" class="btn btn-outline-danger btn-sm mt-3">
+                    Gestionar tipos
+                </a>
+            </div>
+        </div>
+    </div>
+    @endcan
+
+    {{-- Permisos por Categorías --}}
+    @can('permissions_categorias.view')
+    <div class="col-md-4 mt-4">
+        <div class="card text-center shadow-sm">
+            <div class="card-header">
+                <i class="fas fa-layer-group fa-3x"></i>
+            </div>
+            <div class="card-body">
+                <h5 class="card-title">Permisos por Categorías</h5>
+                <a href="{{ route('permissions.categorias.index') }}" class="btn btn-outline-dark btn-sm mt-3">
+                    Gestionar categorías
+                </a>
+            </div>
+        </div>
+    </div>
+    @endcan
+
     {{-- Centros --}}
     @can('centros.view')
     <div class="col-md-4 mt-4">

--- a/resources/views/admin/estadisticas/_kpis.blade.php
+++ b/resources/views/admin/estadisticas/_kpis.blade.php
@@ -1,0 +1,38 @@
+<div class="row mb-4">
+    <div class="col-md-3">
+        <div class="card text-center shadow-sm">
+            <div class="card-body">
+                <h6 class="text-muted">Total Preinscritos</h6>
+                <h2 class="fw-bold text-sena">{{ $kpis['total'] }}</h2>
+            </div>
+        </div>
+    </div>
+    <div class="col-md-3">
+        <div class="card text-center shadow-sm">
+            <div class="card-body">
+                <h6 class="text-muted">Con Novedad</h6>
+                <h2 class="fw-bold text-warning">{{ $kpis['con_novedad'] }}</h2>
+            </div>
+        </div>
+    </div>
+    <div class="col-md-3">
+        <div class="card text-center shadow-sm">
+            <div class="card-body">
+                <h6 class="text-muted">Novedad Resuelta</h6>
+                <h2 class="fw-bold text-success">{{ $kpis['novedad_resuelta'] }}</h2>
+            </div>
+        </div>
+    </div>
+    <div class="col-md-3">
+        <div class="card text-center shadow-sm">
+            <div class="card-body">
+                <h6 class="text-muted">Estados</h6>
+                <ul class="list-unstyled mb-0">
+                    @foreach($kpis['por_estado'] as $estado => $total)
+                        <li><span class="fw-semibold">{{ $estado }}:</span> {{ $total }}</li>
+                    @endforeach
+                </ul>
+            </div>
+        </div>
+    </div>
+</div>

--- a/resources/views/admin/estadisticas/index.blade.php
+++ b/resources/views/admin/estadisticas/index.blade.php
@@ -1,0 +1,166 @@
+@extends('layouts.admin')
+
+@section('title', 'Estadísticas de Preinscritos')
+
+@section('content_header')
+<h1 class="m-0">Estadísticas de Preinscritos</h1>
+@stop
+
+@section('content')
+<div class="container-fluid">
+    @include('admin.estadisticas._kpis', ['kpis' => $kpis])
+
+    <div class="row mb-4">
+        <div class="col-md-6">
+            <div class="card shadow-sm mb-3">
+                <div class="card-header bg-sena text-white">Preinscritos por Programa (Top 10)</div>
+                <div class="card-body">
+                    <ul class="list-group mb-3">
+                        @foreach($kpis['top_programas'] as $row)
+                        <li class="list-group-item d-flex justify-content-between align-items-center">
+                            {{ $row['programa'] }}
+                            <span class="badge bg-primary rounded-pill">{{ $row['total'] }}</span>
+                        </li>
+                        @endforeach
+                    </ul>
+                    <canvas id="graficoProgramas" height="220"></canvas>
+                </div>
+            </div>
+        </div>
+        <div class="col-md-6">
+            <div class="card shadow-sm mb-3">
+                <div class="card-header bg-sena text-white">Evolución Mensual (12 meses)</div>
+                <div class="card-body">
+                    @if(count($kpis['evolucion']) > 1)
+                        <canvas id="graficoEvolucion" height="220"></canvas>
+                    @elseif(count($kpis['evolucion']) === 1)
+                        <canvas id="graficoEvolucion" height="220"></canvas>
+                        <div class="alert alert-warning mt-3">
+                            No hay datos históricos suficientes para mostrar una evolución mensual. Se muestra solo el mes actual.
+                        </div>
+                    @else
+                        <div class="alert alert-info">
+                            No existen datos de evolución mensual. Mostrando datos de prueba.
+                        </div>
+                        <canvas id="graficoEvolucion" height="220"></canvas>
+                    @endif
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <div class="row mb-4">
+        <div class="col-md-6">
+            <div class="card shadow-sm mb-3">
+                <div class="card-header bg-sena text-white">Preinscritos por Estado</div>
+                <div class="card-body">
+                    <canvas id="graficoEstados" height="220"></canvas>
+                    <table class="table table-bordered table-sm mt-3">
+                        <thead>
+                            <tr>
+                                <th>Estado</th>
+                                <th>Total</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            @foreach($kpis['por_estado'] as $estado => $total)
+                                <tr>
+                                    <td>{{ $estado }}</td>
+                                    <td>{{ $total }}</td>
+                                </tr>
+                            @endforeach
+                        </tbody>
+                    </table>
+                </div>
+            </div>
+        </div>
+        <div class="col-md-6">
+            <div class="card shadow-sm mb-3">
+                <div class="card-header bg-sena text-white">Preinscritos por Programa (Todos)</div>
+                <div class="card-body">
+                    <table class="table table-bordered table-sm">
+                        <thead>
+                            <tr>
+                                <th>Programa</th>
+                                <th>Total</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            @foreach($kpis['por_programa'] as $programa_id => $total)
+                            <tr>
+                                <td>{{ $programas[$programa_id] ?? 'N/A' }}</td>
+                                <td>{{ $total }}</td>
+                            </tr>
+                            @endforeach
+                        </tbody>
+                    </table>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <div class="row mb-4">
+        <div class="row mb-4">
+            <div class="col-12">
+                <div class="card shadow-sm mb-3">
+                    <div class="card-header bg-sena text-white">Comparativo de Inscritos, Faltantes y Rechazados por Programa</div>
+                    <div class="card-body">
+                        <canvas id="graficoComparativoProgramas" height="320"></canvas>
+                        <table class="table table-bordered table-sm mt-3">
+                            <thead>
+                                <tr>
+                                    <th>Programa</th>
+                                    <th>Inscritos</th>
+                                    <th>Faltantes</th>
+                                    <th>Rechazados</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                @for($i = 0; $i < count($kpis['grafica_programas']['nombres']); $i++)
+                                    <tr>
+                                        <td>{{ $kpis['grafica_programas']['nombres'][$i] }}</td>
+                                        <td>{{ $kpis['grafica_programas']['inscritos'][$i] }}</td>
+                                        <td>{{ $kpis['grafica_programas']['faltantes'][$i] }}</td>
+                                        <td>{{ $kpis['grafica_programas']['rechazados'][$i] }}</td>
+                                    </tr>
+                                @endfor
+                            </tbody>
+                        </table>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+    <script>
+        window.estadisticas = @json($kpis);
+        // Datos de prueba para evolución mensual si no hay datos
+        if (!window.estadisticas.evolucion || Object.keys(window.estadisticas.evolucion).length === 0) {
+            window.estadisticas.evolucion = {
+                '2025-03': 10,
+                '2025-04': 15,
+                '2025-05': 20,
+                '2025-06': 18,
+                '2025-07': 22,
+                '2025-08': 25,
+                '2025-09': 30,
+                '2025-10': 28,
+                '2025-11': 35,
+                '2025-12': 40,
+                '2026-01': 50,
+                '2026-02': 265
+            };
+        }
+        // Datos de prueba para gráfico de estados si no hay datos
+        if (!window.estadisticas.por_estado || Object.keys(window.estadisticas.por_estado).length === 0) {
+            window.estadisticas.por_estado = {
+                'inscrito': 120,
+                'con_novedad': 15,
+                'rechazado': 8,
+                'pendiente': 5
+            };
+        }
+    </script>
+    @vite(['resources/js/admin/estadisticas.js'])
+    @stop

--- a/resources/views/admin/programas/index.blade.php
+++ b/resources/views/admin/programas/index.blade.php
@@ -28,7 +28,43 @@
 </div>
 @stop
 
+
+
 @section('content')
+
+@php
+    $redes = \App\Models\Red::all();
+    $filtroRed = request('red');
+    $filtroNombre = request('nombre');
+    $filtroFicha = request('ficha');
+@endphp
+
+<div class="card mb-4">
+    <div class="card-body">
+        <form method="GET" class="row g-3 align-items-end">
+            <div class="col-md-4">
+                <label class="form-label fw-semibold">Red tecnológica</label>
+                <select name="red" class="form-select" onchange="this.form.submit()">
+                    <option value="">Todas las redes</option>
+                    @foreach ($redes as $red)
+                        <option value="{{ $red->id }}" @selected($filtroRed == $red->id)>{{ $red->nombre }}</option>
+                    @endforeach
+                </select>
+            </div>
+            <div class="col-md-4">
+                <label class="form-label fw-semibold">Nombre</label>
+                <input type="text" name="nombre" class="form-control" value="{{ $filtroNombre }}" placeholder="Buscar por nombre..." autocomplete="off">
+            </div>
+            <div class="col-md-3">
+                <label class="form-label fw-semibold">Número de ficha</label>
+                <input type="text" name="ficha" class="form-control" value="{{ $filtroFicha }}" placeholder="Buscar por ficha..." autocomplete="off">
+            </div>
+            <div class="col-md-1 d-flex align-items-end">
+                <button type="submit" class="btn btn-outline-primary w-100"><i class="fas fa-search"></i></button>
+            </div>
+        </form>
+    </div>
+</div>
 
 @if($programas->isEmpty())
 <div class="alert alert-info">

--- a/resources/views/partials/sidebar.blade.php
+++ b/resources/views/partials/sidebar.blade.php
@@ -44,6 +44,17 @@
                 </a>
             </li>
 
+                {{-- Detalles de Programas --}}
+                @can('programa_detalles.view')
+                <li class="sidebar-nav-item">
+                    <a href="{{ route('programa_detalles.index') }}"
+                       class="sidebar-nav-link {{ request()->routeIs('programa_detalles.*') ? 'active' : '' }}">
+                        <i class="bi bi-info-circle"></i>
+                        <span>Detalles de Programas</span>
+                    </a>
+                </li>
+                @endcan
+
             {{-- Preinscritos --}}
             @can('preinscritos.admin')
             <li class="sidebar-nav-item">
@@ -98,6 +109,17 @@
             </li>
             @endcan
 
+                {{-- Permisos por Categorías --}}
+                @can('permissions_categorias.view')
+                <li class="sidebar-nav-item">
+                    <a href="{{ route('permissions.categorias.index') }}"
+                       class="sidebar-nav-link {{ request()->routeIs('permissions.categorias.*') ? 'active' : '' }}">
+                        <i class="bi bi-layers"></i>
+                        <span>Permisos por Categorías</span>
+                    </a>
+                </li>
+                @endcan
+
             {{-- Reportes de Preinscritos --}}
             @can('preinscritos.export')
             <li class="sidebar-nav-item">
@@ -133,6 +155,17 @@
                     <span>Noticias</span>
                 </a>
             </li>
+
+                {{-- Carousel del Home --}}
+                @can('admin.home-carousel.view')
+                <li class="sidebar-nav-item">
+                    <a href="{{ route('admin.home-carousel.index') }}"
+                       class="sidebar-nav-link {{ request()->routeIs('admin.home-carousel.*') ? 'active' : '' }}">
+                        <i class="bi bi-images"></i>
+                        <span>Carousel del Home</span>
+                    </a>
+                </li>
+                @endcan
 
             {{-- Historias de Éxito --}}
             <li class="sidebar-nav-item">

--- a/resources/views/partials/sidebar.blade.php
+++ b/resources/views/partials/sidebar.blade.php
@@ -35,6 +35,17 @@
                 <small class="text-uppercase opacity-75">Contenido</small>
             </li>
 
+            {{-- Estadísticas de Preinscritos --}}
+            @can('preinscritos.estadisticas.view')
+            <li class="sidebar-nav-item">
+                <a href="{{ route('admin.estadisticas-preinscritos.index') }}"
+                   class="sidebar-nav-link {{ request()->routeIs('admin.estadisticas-preinscritos.*') ? 'active' : '' }}">
+                    <i class="bi bi-bar-chart"></i>
+                    <span>Estadísticas Preinscritos</span>
+                </a>
+            </li>
+            @endcan
+
             {{-- Programas --}}
             <li class="sidebar-nav-item">
                 <a href="{{ route('programas.index') }}"

--- a/resources/views/public/home.blade.php
+++ b/resources/views/public/home.blade.php
@@ -175,6 +175,11 @@
             <h2 class="section-title">Programas Destacados</h2>
             <p class="section-subtitle">Explora rutas formativas con alta empleabilidad y cupos limitados</p>
             <p class="section-subtitle">Recomendado: programas tecnicos, tecnologicos y cursos cortos con enfoque practico</p>
+            <div class="d-flex justify-content-end mt-2">
+                <a href="{{ route('public.programasDeFormacion.index') }}" class="btn btn-outline-sena fw-semibold">
+                    <i class="bi bi-list-ul me-2"></i>Ver todos los programas
+                </a>
+            </div>
         </div>
         
         <div class="category-tabs">
@@ -210,6 +215,11 @@
                             {{ $programa->modalidad ?? 'Presencial' }}
                         </p>
                         <p class="card-price">Formación 100% gratuita</p>
+                        <div class="mt-2">
+                            <a href="{{ route('public.programasDeFormacion.show', $programa) }}" class="btn btn-outline-sena btn-sm fw-semibold">
+                                <i class="bi bi-eye me-1"></i>Ver detalles
+                            </a>
+                        </div>
                     </div>
                 </div>
             @empty

--- a/routes/web.php
+++ b/routes/web.php
@@ -126,6 +126,16 @@ Route::middleware(['auth', 'verified', 'can:programas.view'])
             ->parameters(['content_public_programas' => 'content_public_programa']);
     });
 
+/*--------------------------------------------------------------------------
+| Estadísticas de Preinscritos (ADMIN)
+|--------------------------------------------------------------------------*/
+Route::middleware(['auth', 'verified', 'can:preinscritos.estadisticas.view'])
+    ->prefix('admin')
+    ->group(function () {
+        Route::get('estadisticas-preinscritos', [\App\Http\Controllers\Admin\EstadisticasPreinscritosController::class, 'index'])
+            ->name('admin.estadisticas-preinscritos.index');
+    });
+
 /*
 |--------------------------------------------------------------------------
 | Roles (ADMIN)

--- a/routes/web.php
+++ b/routes/web.php
@@ -115,6 +115,17 @@ Route::middleware(['auth', 'verified', 'can:users.manage'])
         Route::resource('users', UserController::class);
     });
 
+/*--------------------------------------------------------------------------
+| Contenido Público de Programas (ADMIN)
+|--------------------------------------------------------------------------*/
+Route::middleware(['auth', 'verified', 'can:programas.view'])
+    ->prefix('admin')
+    ->group(function () {
+        Route::resource('content_public_programas', App\Http\Controllers\Admin\ContentPublicProgramaController::class)
+            ->names('admin.content_public_programas')
+            ->parameters(['content_public_programas' => 'content_public_programa']);
+    });
+
 /*
 |--------------------------------------------------------------------------
 | Roles (ADMIN)

--- a/vite.config.js
+++ b/vite.config.js
@@ -40,6 +40,7 @@ export default defineConfig({
                 /* JavaScript */
                 'resources/js/common/app.js',
                 'resources/js/admin/admin.js',
+                'resources/js/admin/estadisticas.js',
                 'resources/js/public/public.js'
             ],
             refresh: true,


### PR DESCRIPTION
Mejoras administrativas recientes: filtros avanzados en programas, mejoras en dashboard, sidebar y home público. Preparación para integración de vista de estadísticas de preinscritos. Estructura de rutas y vistas administrativas optimizada para futuras fases de implementación de estadísticas. [Preparación para Fase Estadísticas]
- Cambiado el color de la barra 'Faltantes' en la gráfica comparativa a azul oscuro SENA (#00324d) y 'Rechazados' a naranja fuerte (#ff6600) para mayor equilibrio visual.
- Ahora la tabla comparativa muestra el nombre del programa en vez del número de ficha.
- Refactor de colores para accesibilidad y experiencia de usuario.
- Recompilados los assets JS y limpiadas las cachés de Laravel.
- - Agregado campo programa_id (FK a programas) y campos nombres/apellidos a preinscritos_rechazados.
- Migración y script para poblar programa_id, nombres, apellidos y preinscrito_id (FK a preinscritos) usando coincidencia flexible.
- Ahora ambas tablas pueden relacionarse y consultarse eficientemente.
- Estructura lista para reportes y trazabilidad cruzada entre preinscritos y rechazados.